### PR TITLE
fix: widen eslint peer dep to >=9 and exclude json-only dir from lint

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -13,14 +13,11 @@ export default tseslint.config(
       },
     },
     rules: {
-      "@typescript-eslint/no-unused-vars": [
-        "error",
-        { argsIgnorePattern: "^_" },
-      ],
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
       "@typescript-eslint/no-explicit-any": "warn",
     },
   },
   {
     ignores: ["dist/", "node_modules/", ".next/", ".vinxi/"],
-  }
+  },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "typescript": "^6.0.2"
       },
       "peerDependencies": {
-        "eslint": "^9.0.0",
+        "eslint": ">=9.0.0",
         "prettier": "^3.0.0",
         "typescript": "^5.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "tailwind"
   ],
   "scripts": {
-    "lint": "eslint eslint/ prettier/ tailwind/ typescript/",
+    "lint": "eslint eslint/ prettier/ tailwind/",
     "format:check": "prettier --check eslint/ prettier/ tailwind/ typescript/"
   },
   "peerDependencies": {
-    "eslint": "^9.0.0",
+    "eslint": ">=9.0.0",
     "prettier": "^3.0.0",
     "typescript": "^5.3.0"
   },


### PR DESCRIPTION
## Summary
- Changed `peerDependencies.eslint` from `^9.0.0` to `>=9.0.0` so consumer repos on ESLint 10 satisfy the peer dep
- Removed `typescript/` from the lint script since it only contains `.json` files that ESLint ignores (kept in `format:check` for Prettier)
- Auto-formatted `eslint/index.js` to pass `format:check`

## Test plan
- [x] `npm run lint` passes locally
- [x] `npm run format:check` passes locally