### PR TITLE
chore: add badges, CODEOWNERS, and local dev setup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @PetarStoev02

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,30 @@ Thanks for your interest in contributing to w3-kit's shared configs!
 
 Check [open issues](https://github.com/w3-kit/config/issues) for ideas.
 
+## Local development
+
+```bash
+git clone https://github.com/YOUR_USERNAME/config.git
+cd config
+npm install
+```
+
+### Testing configs locally
+
+Link the package locally and test in another w3-kit repo:
+
+```bash
+npm link
+cd ../cli  # or any other repo
+npm link @w3-kit/config
+```
+
+### Run all CI checks locally
+
+```bash
+npm run lint && npm run format:check
+```
+
 ## Guidelines
 
 - Keep configs minimal and well-documented

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # @w3-kit/config
 
+[![CI](https://github.com/w3-kit/config/actions/workflows/ci.yml/badge.svg)](https://github.com/w3-kit/config/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/@w3-kit/config)](https://www.npmjs.com/package/@w3-kit/config)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+
 Shared configs for the w3-kit org.
 
 ## Usage


### PR DESCRIPTION
## Summary

- Added CI, npm, and license badges to README.md
- Created `.github/CODEOWNERS` assigning @PetarStoev02 as default reviewer
- Added "Local development" section to CONTRIBUTING.md with clone, link, and CI check instructions

## Test plan

- [ ] Verify badges render correctly on the repo page
- [ ] Confirm CODEOWNERS triggers review requests on new PRs
- [ ] Follow local dev setup steps to ensure instructions are accurate