### PR TITLE
chore: bump to 0.1.1 for npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@w3-kit/config",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Shared configs for the w3-kit org",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

Bump `@w3-kit/config` to `0.1.1` so we can publish to npm. The current npm-published `0.1.0` is stale and blocks consumer dependabot PRs (notably eslint v10 in bot/cli/registry/ui).

## What's in this release (everything since npm 0.1.0)

- `2a608f6` widen eslint peer dep from `^9.0.0` to `>=9.0.0` (the main reason for this release)
- `c31938d` @eslint/js 9.39.4 to 10.0.1 (MAJOR)
- `827052c` globals 15.15.0 to 17.6.0 (MAJOR)
- `a671f06` typescript-eslint 8.58.0 to 8.59.4 (minor)
- `46264c3` dev-dependencies group bump
- CI/Actions infra updates (not consumer-visible)

## Heads up on version choice

Strictly by semver, the @eslint/js and globals MAJOR bumps are runtime deps for this config package. Consumers using `@w3-kit/config/eslint` may see slightly different lint results after this update. If you want to signal that, **bump to `0.2.0` instead of `0.1.1`** before publishing. Patch (`0.1.1`) is fine for an internal org config but minor (`0.2.0`) is more honest.

## What this unblocks downstream

- bot #6 (eslint 9 to 10)
- any future eslint 10.x patches across all consumers

Does NOT unblock TypeScript v6 PRs (bot #5, cli #96, registry #21, ui #121) - those still need a separate `@w3-kit/config` change to widen the typescript peer dep.

## Post-merge steps

```bash
cd config
npm publish
```

(Requires npm access to the @w3-kit org.)