### PR TITLE
chore: support TypeScript 6 in peer dep (0.2.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@w3-kit/config",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Shared configs for the w3-kit org",
   "type": "module",
   "exports": {
@@ -24,7 +24,7 @@
   "peerDependencies": {
     "eslint": ">=9.0.0",
     "prettier": "^3.0.0",
-    "typescript": "^5.3.0"
+    "typescript": ">=5.3.0"
   },
   "dependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary

Widen the typescript peer dep from `^5.3.0` to `>=5.3.0` so consumers can upgrade to TypeScript 6.

## Why

Dependabot opened TS6 bump PRs across the org:
- bot#5, cli#96, registry#21, ui#121

All four fail to install because `@w3-kit/config@0.1.1` pins peer `typescript: ^5.3.0`, rejecting v6. This PR fixes that.

## Why bump to 0.2.0 (not 0.1.2)

This is a new capability (supports a major TS version that didn't exist when 0.1.x shipped), not a bug fix. Minor bump signals consumers can opt in to TS 6 starting from this version.

## Verification

The config repo already uses `typescript@^6.0.2` as a devDep (so the typescript configs themselves have been tested under TS 6). Running locally:

- `npm run lint` - PASS (typescript-eslint@8.58.0 + TS 6 working together)
- `npm run format:check` - PASS

The exported tsconfigs (`base.json`, `node.json`, `react.json`) use `target: ES2022` and `moduleResolution: bundler`, both fully TS 6 compatible. No deprecated options.

## What this unblocks downstream (after publish)

- bot#5 (typescript 5.9 to 6.0.3)
- cli#96 (typescript 5.9 to 6.0.3)
- registry#21 (typescript 5.9 to 6.0.3)
- ui#121 (typescript 4.9 to 6.0.3) - note: ui#121 is currently RED due to other tsconfig issues, may need separate fix

## Post-merge steps

```bash
cd config
npm publish --access public
```

Then trigger `@dependabot recreate` on each TS6 consumer PR so they pick up the new peer dep.